### PR TITLE
[devfix] Simplify PostgreSQL install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.8-buster
 
 COPY requirements.txt /requirements.txt
-RUN pip --no-cache-dir install -r /requirements.txt \
+RUN sed -i 's/psycopg2-binary/psycopg2/g' requirements.txt \
+ && pip --no-cache-dir install -r /requirements.txt \
  && rm /requirements.txt
 
 COPY . /app/.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
 epam.indigo==1.4.0b0  # https://github.com/epam/Indigo
 gunicorn[gevent,setproctitle]==20.0.4  # https://github.com/benoitc/gunicorn
 psycogreen==1.0.2  # https://github.com/psycopg/psycogreen/
-psycopg2==2.8.4  # https://github.com/psycopg/psycopg2
+psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 redis==3.4.1  # https://github.com/antirez/redis
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
 


### PR DESCRIPTION
This PR simplifies the PostgreSQL install by using the "binary" package in requirements.txt. It allows a much simpler developer environment setup. All the dependency steps in the Wiki can be removed if this is merged.

## Background

In version 2.7, the PostgreSQL driver `pyscopg2` delivered the pre-compiled binary along with the source. This allowed developers to install the driver without the need to compile it with external dependencies. It also allowed a production environment to compile it from source with the the `--no-binary` flag in `pip`. This is standard practice for PyPI packages.

This was [changed in version 2.8](https://github.com/psycopg/psycopg2/issues/674), however. There are now two interchangeable packages:

- `pyscopg2-binary`: always installs the pre-compiled driver (recommended for development environments)
- `psycopg2`: always builds the driver from source (recommended for production environments)

## Fix

The `psycopg2` requirement was replaced with `psycopg2-binary`. During the Docker build stage, the `psycopg2` requirement is swapped back in.