### PR TITLE
add validator for inchikey and add to the model

### DIFF
--- a/chemreg/compound/models.py
+++ b/chemreg/compound/models.py
@@ -11,6 +11,7 @@ from chemreg.compound.validators import (
     validate_cid_checksum,
     validate_cid_regex,
     validate_inchikey_computable,
+    validate_inchikey_unique,
 )
 from chemreg.indigo.inchi import get_inchikey
 
@@ -48,7 +49,9 @@ class DefinedCompound(BaseCompound):
 
     """
 
-    molfile = StructureAliasField(validators=[validate_inchikey_computable])
+    molfile = StructureAliasField(
+        validators=[validate_inchikey_computable, validate_inchikey_unique]
+    )
     inchikey = ComputedCharField(compute_from="_inchikey", max_length=29)
 
     @property

--- a/chemreg/compound/tests/factories.py
+++ b/chemreg/compound/tests/factories.py
@@ -37,7 +37,6 @@ class DefinedCompoundFactory(factory.DjangoModelFactory):
 class DefinedCompoundJSONFactory(factory.DictFactory):
     """Manufactures `DefinedCompound` dictionaries."""
 
-    id = factory.Faker("cid")
     molfile = factory.Faker("molfile_v3000")
 
 

--- a/chemreg/compound/tests/test_serializers.py
+++ b/chemreg/compound/tests/test_serializers.py
@@ -57,3 +57,17 @@ def test_compound_serialize(compound):
     model = factory.build()
     serialized = serializer(model)
     assert serialized.data["id"] == model.cid
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("compound", ["DefinedCompound"], indirect=["compound"])
+def test_unique_inchikey(compound):
+    serializer = compound["serializer"]
+    factory = compound["factory"]
+    json_factory = compound["json_factory"]
+    model = factory.create()
+    data = json_factory(molfile=model.molfile)
+    serialized = serializer(data=data)
+    assert not serialized.is_valid()
+    assert "molfile" in serialized.errors
+    assert str(serialized.errors["molfile"][0]) == "InChIKey already exists."

--- a/chemreg/compound/validators.py
+++ b/chemreg/compound/validators.py
@@ -1,5 +1,6 @@
 import re
 
+from django.apps import apps
 from django.core.exceptions import ValidationError
 
 from indigo import IndigoException
@@ -46,7 +47,7 @@ def validate_inchikey_computable(molfile: str) -> None:
     """Validates that an InChIKey can be computed from the provided molfile.
 
     Args:
-        inchikey: The InChIKey string
+        molfile: The molfile string
 
     Raises:
         ValidationError: If the InChIKey cannot be computed.
@@ -55,3 +56,24 @@ def validate_inchikey_computable(molfile: str) -> None:
         get_inchikey(molfile)
     except IndigoException:
         raise ValidationError("InChIKey not computable for provided structure.")
+
+
+def validate_inchikey_unique(molfile: str) -> None:
+    """Validates that an InChIKey computed from the provided molfile is unique.
+
+    Typically, we'd use unique=True to enforce this at the database level, however,
+    sometimes a non-unique inchikey can exist. An admin must verify this is allowed.
+
+    Args:
+        molfile: The molfile string
+
+    Raises:
+        ValidationError: If the InChIKey is not unique.
+    """
+    DefinedCompound = apps.get_model("compound", "DefinedCompound")
+    try:
+        inchikey = get_inchikey(molfile)
+        if DefinedCompound.objects.filter(inchikey=inchikey).exists():
+            raise ValidationError("InChIKey already exists.")
+    except IndigoException:
+        pass


### PR DESCRIPTION
this adds a validator to the DefinedCompound model and then tests it in the serializer. The `test_create_view` test is failing with this submission, but is being re-written in @mcovalt 's current ticket and will be resolved there.