### PR TITLE
[47] Search via molfileV3000

### DIFF
--- a/chemreg/compound/filters.py
+++ b/chemreg/compound/filters.py
@@ -1,0 +1,9 @@
+from django_filters import rest_framework as filters
+
+from chemreg.compound.models import DefinedCompound
+
+
+class DefinedCompoundFilter(filters.FilterSet):
+    class Meta:
+        model = DefinedCompound
+        fields = ["cid", "inchikey"]

--- a/chemreg/compound/filters.py
+++ b/chemreg/compound/filters.py
@@ -1,6 +1,10 @@
 from django_filters import rest_framework as filters
 
 from chemreg.compound.models import DefinedCompound
+from chemreg.compound.validators import (
+    validate_inchikey_computable,
+    validate_molfile_v3000,
+)
 from chemreg.indigo.inchi import get_inchikey
 
 
@@ -8,6 +12,8 @@ class DefinedCompoundFilter(filters.FilterSet):
     molfile_v3000 = filters.CharFilter(method="filter_molfile_v3000", strip=False)
 
     def filter_molfile_v3000(self, queryset, name, value):
+        validate_molfile_v3000(value)
+        validate_inchikey_computable(value)
         inchikey = get_inchikey(value)
         return queryset.filter(inchikey=inchikey)
 

--- a/chemreg/compound/filters.py
+++ b/chemreg/compound/filters.py
@@ -1,9 +1,16 @@
 from django_filters import rest_framework as filters
 
 from chemreg.compound.models import DefinedCompound
+from chemreg.indigo.inchi import get_inchikey
 
 
 class DefinedCompoundFilter(filters.FilterSet):
+    molfile_v3000 = filters.CharFilter(method="filter_molfile_v3000", strip=False)
+
+    def filter_molfile_v3000(self, queryset, name, value):
+        inchikey = get_inchikey(value)
+        return queryset.filter(inchikey=inchikey)
+
     class Meta:
         model = DefinedCompound
-        fields = ["cid", "inchikey"]
+        fields = ["cid", "inchikey", "molfile_v3000"]

--- a/chemreg/compound/tests/test_filters.py
+++ b/chemreg/compound/tests/test_filters.py
@@ -1,0 +1,23 @@
+from rest_framework.test import APIClient
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_defined_compound_filters(defined_compound_factory, user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    compounds = defined_compound_factory.create_batch(2)
+    # Alter the molfile so that we can ensure the lookup is done on the inchikey
+    # URL encode spaces and newlines
+    molfile = (
+        compounds[0]
+        .instance.molfile_v3000.replace("-INDIGO-", "-CHEMREG-")
+        .replace(" ", "+")
+        .replace("\n", "%0A")
+    )
+
+    # Test the filter with valid molfile
+    response = client.get(f"/definedCompounds?filter[molfileV3000]={molfile}")
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["cid"] == compounds[0].instance.cid

--- a/chemreg/compound/tests/test_filters.py
+++ b/chemreg/compound/tests/test_filters.py
@@ -21,3 +21,7 @@ def test_defined_compound_filters(defined_compound_factory, user):
     response = client.get(f"/definedCompounds?filter[molfileV3000]={molfile}")
     assert len(response.data["results"]) == 1
     assert response.data["results"][0]["cid"] == compounds[0].instance.cid
+
+    # Test with invalid molfile
+    response = client.get(f"/definedCompounds?filter[molfileV3000]=foo")
+    assert "Structure is not in V3000 format." in response.data[0]["detail"]

--- a/chemreg/compound/tests/test_views.py
+++ b/chemreg/compound/tests/test_views.py
@@ -73,7 +73,11 @@ def test_definedcompound_detail_attrs(user_factory, defined_compound_factory):
 
 def test_defined_compound_view():
     """Tests that the Defined Compound View Set includes cid and InChIKey as filterset fields."""
-    assert DefinedCompoundViewSet.filterset_class.Meta.fields == ["cid", "inchikey"]
+    assert DefinedCompoundViewSet.filterset_class.Meta.fields == [
+        "cid",
+        "inchikey",
+        "molfile_v3000",
+    ]
 
 
 def test_compound_view():

--- a/chemreg/compound/tests/test_views.py
+++ b/chemreg/compound/tests/test_views.py
@@ -73,7 +73,7 @@ def test_definedcompound_detail_attrs(user_factory, defined_compound_factory):
 
 def test_defined_compound_view():
     """Tests that the Defined Compound View Set includes cid and InChIKey as filterset fields."""
-    assert DefinedCompoundViewSet.filterset_fields == ["cid", "inchikey"]
+    assert DefinedCompoundViewSet.filterset_class.Meta.fields == ["cid", "inchikey"]
 
 
 def test_compound_view():

--- a/chemreg/compound/views.py
+++ b/chemreg/compound/views.py
@@ -1,5 +1,6 @@
 from rest_framework.permissions import IsAdminUser
 
+from chemreg.compound.filters import DefinedCompoundFilter
 from chemreg.compound.models import (
     BaseCompound,
     DefinedCompound,
@@ -24,7 +25,7 @@ class DefinedCompoundViewSet(ModelViewSet):
         "retrieve": DefinedCompoundDetailSerializer,
     }
     valid_post_query_params = ["override"]
-    filterset_fields = ["cid", "inchikey"]
+    filterset_class = DefinedCompoundFilter
 
     def get_serializer_class(self, *args, **kwargs):
         try:

--- a/chemreg/jsonapi/serializers.py
+++ b/chemreg/jsonapi/serializers.py
@@ -49,9 +49,7 @@ class AutoRelatedMixin:
             if not getattr(cls, "included_serializers", None):
                 cls.included_serializers = included_serializers
             else:
-                cls.included_serializers = cls.included_serializers.update(
-                    included_serializers
-                )
+                cls.included_serializers.update(included_serializers)
         return super().__new__(cls, *args, **kwargs)
 
 

--- a/chemreg/openapi/schemas/compound/definedCompound.libsonnet
+++ b/chemreg/openapi/schemas/compound/definedCompound.libsonnet
@@ -17,6 +17,7 @@ local baseCompound = import 'baseCompound.libsonnet';
       description: 'A [v3000 MDL Molfile](https://en.wikipedia.org/wiki/Chemical_table_file#The_Extended_Connection_Table_(V3000)) representing this compound. Newlines must be escaped (e.g. `\\n`) and spaces preserved.',
       example: '\n  -INDIGO-04212015202D\n\n  0  0  0  0  0  0  0  0  0  0  0 V3000\nM  V30 BEGIN CTAB\nM  V30 COUNTS 2 1 0 0 0\nM  V30 BEGIN ATOM\nM  V30 1 O 0.0 0.0 0.0 0\nM  V30 2 O 0.0 0.0 0.0 0\nM  V30 END ATOM\nM  V30 BEGIN BOND\nM  V30 1 2 1 2\nM  V30 END BOND\nM  V30 END CTAB\nM  END\n',
       oneOfGroup: 'structure',
+      filter: true,
     },
     smiles: {
       type: 'string',


### PR DESCRIPTION
Closes #47 

The molfileV3000 field is filterable. First, the molfileV3000 is converted to an inchikey, then the inchikey is used to filter the queryset. Validation is performed on the molfileV3000 to make sure it is indeed a molfileV3000.

Make sure to URL encode the molfileV3000. This means replace spaces with `+` and newlines with `%0A`.

ToDo
- [x] Move DefinedCompound filters to class for more filtering capabilities
- [x] Add filter method for molfileV3000 that first converts the molfileV3000 into an InChIKey, then filters on DefinedCompound.inchikey
- [x] Validate that the molfileV3000 is valid in the filter class