### PR TITLE
Format mrvfile

### DIFF
--- a/chemreg/compound/tests/fakers.py
+++ b/chemreg/compound/tests/fakers.py
@@ -30,9 +30,7 @@ class CompoundFaker(BaseProvider):
         return self.molecule().molfile()
 
     def mrvfile(self):
-        s = format_mrvfile(self.molecule().cml())
-        print(s)
-        return s
+        return format_mrvfile(self.molecule().cml())
 
     def molfile_v2000(self):
         smiles_str = self.random_element(self.compounds)

--- a/chemreg/compound/tests/fakers.py
+++ b/chemreg/compound/tests/fakers.py
@@ -5,7 +5,7 @@ import pickle
 from faker.providers import BaseProvider
 from indigo import Indigo
 
-from chemreg.compound.utils import build_cid
+from chemreg.compound.utils import build_cid, format_mrvfile
 
 with bz2.open(os.path.join(os.path.dirname(__file__), "compounds.bz2"), "rb") as f:
     COMPOUNDS = pickle.load(f)
@@ -30,7 +30,9 @@ class CompoundFaker(BaseProvider):
         return self.molecule().molfile()
 
     def mrvfile(self):
-        return self.molecule().cml()
+        s = format_mrvfile(self.molecule().cml())
+        print(s)
+        return s
 
     def molfile_v2000(self):
         smiles_str = self.random_element(self.compounds)


### PR DESCRIPTION
I talked through this a bit with @AScaduto today, but for now this branch can take the SMILEs produced in the CompoundFactory and format the `mrvfile` to be a string that can be loaded in to the MarvinJS window through the textarea and import button. 

This string can be grabbed by running tests and having a print statement with the `-s` flag or you can just put a failing assertion in the test after the ill_defined_compound_factory has been built and run the tests with `--pdb` to get the string. In order to put the string into Postman, replace all `"` with `'` and it should work.

These strings will not have coordinates in them which we are going to eventually validate, but don't at the moment. If you want to get an mrv string with coordinates, if you load one of these into MarvinJS and then hit the export button you will then get a string with coordinates, this is what I have done for the vuejs ticket that I am working on #29 in order to have the window load the compound in a clean way. Without the coordinates all of the elements come into the Marvin window stacked on top of one another.

I am writing this mostly because I am going to be out next week and if someone else wants to find out where I am at with my ticket they can find out here. I have a branch that will load compounds into the Marvin window, but without seed data, the above steps will be involved in getting it to work for the moment. This begs the question as to how we will deal with tests and seed data in the API for the vuejs app, we are currently using **Karyn** as the user in tests now but will need to figure out how to test some of the functionality in vue which will be important, but I just want to get this ticket done.