### PR TITLE
129 set up django monitoring

### DIFF
--- a/chemreg/common/tests.py
+++ b/chemreg/common/tests.py
@@ -40,3 +40,8 @@ def test_user_link(user_factory):
         user_2.save()
         assert user_2.created_by_id == user_1.pk
         assert user_2.updated_by_id == user_2.pk
+
+
+def test_prometheus_metrics_endpoint(client):
+    response = client.get("/metrics")
+    assert response.status_code == 200

--- a/config/settings.py
+++ b/config/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     # Third party apps
     "computed_property",
+    "django_prometheus",
     "polymorphic",
     "rest_framework",
     "partialsmiles",
@@ -66,6 +67,7 @@ INSTALLED_APPS = [
 MEDIA_ROOT = APPS_DIR("media")
 MEDIA_URL = "/media/"
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -75,6 +77,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "crum.CurrentRequestUserMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 ROOT_URLCONF = "config.urls." + env("URL_CONF")
 SECRET_KEY = env("SECRET_KEY")

--- a/config/urls/admin.py
+++ b/config/urls/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path, url
 
 urlpatterns = [
     path("", admin.site.urls),
+    url("", include("django_prometheus.urls")),
 ]

--- a/config/urls/admin.py
+++ b/config/urls/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
-from django.urls import include, path, url
+from django.urls import include, path
 
 urlpatterns = [
     path("", admin.site.urls),
-    url("", include("django_prometheus.urls")),
+    path("", include("django_prometheus.urls")),
 ]

--- a/config/urls/api.py
+++ b/config/urls/api.py
@@ -1,7 +1,8 @@
-from django.urls import include, path
+from django.urls import include, path, url
 
 urlpatterns = [
     path("", include("chemreg.openapi.urls")),
     path("", include("chemreg.auth.urls")),
     path("", include("chemreg.compound.urls")),
+    url("", include("django_prometheus.urls")),
 ]

--- a/config/urls/api.py
+++ b/config/urls/api.py
@@ -1,8 +1,8 @@
-from django.urls import include, path, url
+from django.urls import include, path
 
 urlpatterns = [
     path("", include("chemreg.openapi.urls")),
     path("", include("chemreg.auth.urls")),
     path("", include("chemreg.compound.urls")),
-    url("", include("django_prometheus.urls")),
+    path("", include("django_prometheus.urls")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,11 @@ redis==3.4.1  # https://github.com/antirez/redis
 whitenoise==5.0.1  # https://github.com/evansd/whitenoise
 
 
-# Code quality, testing, and documentation
+# Code quality, testing, monitoring and documentation
 # ------------------------------------------------------------------------------
 black==19.10b0  # https://github.com/ambv/black
 coverage==5.0.3  # https://github.com/nedbat/coveragepy
+django-prometheus==2.0.0  # https://github.com/korfuri/django-prometheus
 factory-boy==2.12.0  # https://github.com/FactoryBoy/factory_boy
 flake8==3.7.9  # https://github.com/PyCQA/flake8
 flake8-black==0.1.1  # https://github.com/peterjc/flake8-black


### PR DESCRIPTION
Closes #129 

@dmlyons2  - I was able to set up a working /metrics endpoint i.e.: http://127.0.0.1:8000/metrics 
but based on the ticket's acceptance criteria I was unsure how much further to take this one. Do you want me to set up the prometheus docker container and dashboard as well? 

Config info for this ticket found here:
https://github.com/korfuri/django-prometheus
https://www.sipios.com/blog-tech/monitoring
