### PR TITLE
endpoints for owners, externalContact for includes in ListSerializer

### DIFF
--- a/chemreg/lists/serializers.py
+++ b/chemreg/lists/serializers.py
@@ -54,7 +54,7 @@ class ListSerializer(HyperlinkedModelSerializer):
 
     list_accessibility = AccessibilityTypeSerializer
     external_contact = ExternalContactSerializer
-    owners = UserSerializer(read_only=True, many=True)
+    owners = UserSerializer
     types = ListTypeSerializer
 
     class Meta:

--- a/chemreg/lists/tests/test_serializers.py
+++ b/chemreg/lists/tests/test_serializers.py
@@ -65,6 +65,7 @@ def test_list_serializer():
 @pytest.mark.django_db
 def test_list(list_factory):
     serializer = list_factory.build()
+    assert 1 == 0
     assert serializer.is_valid()
     serializer.save()
 

--- a/chemreg/lists/urls.py
+++ b/chemreg/lists/urls.py
@@ -11,6 +11,7 @@ router.register(views.ListViewSet)
 router.register(views.ListTypeViewSet)
 router.register(views.RecordViewSet)
 router.register(views.RecordIdentifierViewSet)
+router.register(views.ExternalContactViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/chemreg/users/serializers.py
+++ b/chemreg/users/serializers.py
@@ -1,9 +1,8 @@
-from rest_framework import serializers
-
+from chemreg.jsonapi.serializers import HyperlinkedModelSerializer
 from chemreg.users.models import User
 
 
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(HyperlinkedModelSerializer):
     """The serializer for `User`."""
 
     class Meta:

--- a/chemreg/users/tests/factories.py
+++ b/chemreg/users/tests/factories.py
@@ -2,6 +2,9 @@ from typing import Any, Sequence
 
 from factory import DjangoModelFactory, Faker, post_generation
 
+# will probably need to be used, but may need a separate user
+# serializer and user model facotry, not sure yet.
+# from chemreg.common.factory import DjangoSerializerFactory
 from chemreg.users.models import User
 
 

--- a/chemreg/users/urls.py
+++ b/chemreg/users/urls.py
@@ -1,0 +1,12 @@
+from django.urls import include, path
+
+from chemreg.jsonapi.routers import SimpleRouter
+from chemreg.users import views
+
+# Create a router and register our viewsets with it.
+router = SimpleRouter()
+router.register(views.UserViewSet)
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/chemreg/users/views.py
+++ b/chemreg/users/views.py
@@ -1,0 +1,9 @@
+from chemreg.jsonapi.views import ModelViewSet
+from chemreg.users.models import User
+from chemreg.users.serializers import UserSerializer
+
+
+class UserViewSet(ModelViewSet):
+
+    queryset = User.objects.all()
+    serializer_class = UserSerializer

--- a/config/urls/api.py
+++ b/config/urls/api.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("", include("chemreg.openapi.urls")),
+    path("", include("chemreg.users.urls")),
     path("", include("chemreg.auth.urls")),
     path("", include("chemreg.compound.urls")),
     path("", include("chemreg.substance.urls")),


### PR DESCRIPTION
tests will need to be built for these new endpoints in a future ticket which has yet to be made. I have inherited the `HyperLinkedModelSerializer` to the `UserSerializer` and created the necessary views/urls here. 

One of the current problems in testing that I have found is that the list_factory as it existed wasn't validating a required field of `owners` which will have to be ironed out here. I have a failing assert statement in a test to begin debugging. There is a bit of work to do with the `factory.post_generation` wrapper in the factory so that we always get an owner on a build or create.