### PR TITLE
290 docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,7 +329,3 @@ chemreg/media/
 .ipython/
 .env
 .sqlite3
-
-# docker-compose
-docker-compose.yaml
-docker-compose.yml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,44 +3,51 @@ version: "3.1"
 services:
     chemreg-api:
         build:
-            context: https://github.com/Chemical-Curation/chemcurator_django.git#${ADMIN_BRANCH}
+            context: https://github.com/Chemical-Curation/chemcurator_django.git#${API_BRANCH}
         image: chemreg-django
         restart: unless-stopped
         environment:
             CACHE_URL: redis://redis:6379/0
             DATABASE_URL: postgres://pgbouncer:5432/${SQL_DATABASE}
-            DEBUG: "false"
+            DEBUG: ${DEBUG}
             SECRET_KEY: ${API_SECRET_KEY}
-            SESSION_COOKIE_AGE: 900
+            SESSION_COOKIE_AGE: ${SESSION_COOKIE_AGE}
             URL_CONF: api
             WEB_CONCURRENCY: 8
             WHITELIST_CORS: ${SPA_DOMAIN}
             WHITELIST_HOST: ${API_DOMAIN}
-            WHITELIST_LOCAL: "false"
-            RESOLUTION_URL: https://point.to.resolver.url
+            WHITELIST_LOCAL: ${WHITELIST_LOCAL}
+            RESOLUTION_URL: ${RESOLUTION_URL}
         ports:
             - 8000:8000
+        depends_on:
+          - pgbouncer
+
     chemreg-admin:
         build:
-            context: https://github.com/Chemical-Curation/chemcurator_django.git#${API_BRANCH}
+            context: https://github.com/Chemical-Curation/chemcurator_django.git#${ADMIN_BRANCH}
         image: chemreg-django
         restart: unless-stopped
         environment:
             CACHE_URL: redis://redis:6379/1
             DATABASE_URL: postgres://pgbouncer:5432/${SQL_DATABASE}
-            DEBUG: "false"
+            DEBUG: ${DEBUG}
             SECRET_KEY: ${ADMIN_SECRET_KEY}
-            SESSION_COOKIE_AGE: 900
+            SESSION_COOKIE_AGE: ${SESSION_COOKIE_AGE}
             URL_CONF: admin
             WEB_CONCURRENCY: 2
             WHITELIST_HOST: ${ADMIN_DOMAIN}
-            WHITELIST_LOCAL: "false"
-            RESOLUTION_URL: https://point.to.resolver.url
+            WHITELIST_LOCAL: ${WHITELIST_LOCAL}
+            RESOLUTION_URL: ${RESOLUTION_URL}
         ports:
             - 8001:8000
+        depends_on:
+          - pgbouncer
+
     redis:
         image: redis:5-alpine
         restart: unless-stopped
+
     pgbouncer:
         image: pgbouncer/pgbouncer:1.12.0
         restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,18 +6,16 @@ services:
             context: https://github.com/Chemical-Curation/chemcurator_django.git#${API_BRANCH}
         image: chemreg-django
         restart: unless-stopped
+        env_file:
+          - .env
         environment:
             CACHE_URL: redis://redis:6379/0
             DATABASE_URL: postgres://pgbouncer:5432/${SQL_DATABASE}
-            DEBUG: ${DEBUG}
             SECRET_KEY: ${API_SECRET_KEY}
-            SESSION_COOKIE_AGE: ${SESSION_COOKIE_AGE}
             URL_CONF: api
             WEB_CONCURRENCY: 8
             WHITELIST_CORS: ${SPA_DOMAIN}
             WHITELIST_HOST: ${API_DOMAIN}
-            WHITELIST_LOCAL: ${WHITELIST_LOCAL}
-            RESOLUTION_URL: ${RESOLUTION_URL}
         ports:
             - 8000:8000
         depends_on:
@@ -28,17 +26,15 @@ services:
             context: https://github.com/Chemical-Curation/chemcurator_django.git#${ADMIN_BRANCH}
         image: chemreg-django
         restart: unless-stopped
+        env_file:
+          - .env
         environment:
             CACHE_URL: redis://redis:6379/1
             DATABASE_URL: postgres://pgbouncer:5432/${SQL_DATABASE}
-            DEBUG: ${DEBUG}
             SECRET_KEY: ${ADMIN_SECRET_KEY}
-            SESSION_COOKIE_AGE: ${SESSION_COOKIE_AGE}
             URL_CONF: admin
             WEB_CONCURRENCY: 2
             WHITELIST_HOST: ${ADMIN_DOMAIN}
-            WHITELIST_LOCAL: ${WHITELIST_LOCAL}
-            RESOLUTION_URL: ${RESOLUTION_URL}
         ports:
             - 8001:8000
         depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,52 @@
+version: "3.1"
+
+services:
+    chemreg-api:
+        build:
+            context: https://github.com/Chemical-Curation/chemcurator_django.git#${ADMIN_BRANCH}
+        image: chemreg-django
+        restart: unless-stopped
+        environment:
+            CACHE_URL: redis://redis:6379/0
+            DATABASE_URL: postgres://pgbouncer:5432/${SQL_DATABASE}
+            DEBUG: "false"
+            SECRET_KEY: ${API_SECRET_KEY}
+            SESSION_COOKIE_AGE: 900
+            URL_CONF: api
+            WEB_CONCURRENCY: 8
+            WHITELIST_CORS: ${SPA_DOMAIN}
+            WHITELIST_HOST: ${API_DOMAIN}
+            WHITELIST_LOCAL: "false"
+            RESOLUTION_URL: https://point.to.resolver.url
+        ports:
+            - 8000:8000
+    chemreg-admin:
+        build:
+            context: https://github.com/Chemical-Curation/chemcurator_django.git#${API_BRANCH}
+        image: chemreg-django
+        restart: unless-stopped
+        environment:
+            CACHE_URL: redis://redis:6379/1
+            DATABASE_URL: postgres://pgbouncer:5432/${SQL_DATABASE}
+            DEBUG: "false"
+            SECRET_KEY: ${ADMIN_SECRET_KEY}
+            SESSION_COOKIE_AGE: 900
+            URL_CONF: admin
+            WEB_CONCURRENCY: 2
+            WHITELIST_HOST: ${ADMIN_DOMAIN}
+            WHITELIST_LOCAL: "false"
+            RESOLUTION_URL: https://point.to.resolver.url
+        ports:
+            - 8001:8000
+    redis:
+        image: redis:5-alpine
+        restart: unless-stopped
+    pgbouncer:
+        image: pgbouncer/pgbouncer:1.12.0
+        restart: unless-stopped
+        environment:
+            DATABASES_HOST: ${SQL_HOST}
+            DATABASES_PASSWORD: ${SQL_PASSWORD}
+            DATABASES_PORT: ${SQL_PORT}
+            DATABASES_USER: ${SQL_USER}
+            PGBOUNCER_LISTEN_PORT: 5432

--- a/template.env
+++ b/template.env
@@ -15,3 +15,20 @@ WHITELIST_CORS=
 WHITELIST_HOST=
 WHITELIST_LOCAL=true
 WEB_CONCURRENCY=1
+
+# Docker specific Overrides
+#
+# A description of each setting can be found here:
+#https://github.com/Chemical-Curation/chemcurator_django/wiki/Deploying-with-Docker
+ADMIN_BRANCH=master
+ADMIN_DOMAIN=localhost
+ADMIN_SECRET_KEY=
+API_BRANCH=master
+API_DOMAIN=localhost
+API_SECRET_KEY=
+SPA_DOMAIN=localhost
+SQL_DATABASE=chemreg
+SQL_HOST=postgresql
+SQL_PASSWORD=postgres
+SQL_PORT=5432
+SQL_USER=postgres


### PR DESCRIPTION
closes #290 

If you're using the developer setup postgres db you will probably have to `docker rm -f postgresql` and rebuild.  If you want to use the pgadmin you may have to do the same.

Most of this ticket was ensuring I understood how the docker-compose file will allow for interactions on a developer set-up as well as for a production set-up.  There will be changes to the wiki that accompany this.  Please use those as a guide for how to set up the docker environment.

The docker-compose file now first pulls in `.env` file in the root of the repo and then replaces it with container specific overrides using the `env_file` and `environment`.  This means even if a variable is not defined in the `environment` section, it will still get passed into the django instance if it is defined on the `.env` file.

### Wiki Changes

- The [developer setup postgres container](https://github.com/Chemical-Curation/chemcurator_django/wiki/Developer-Setup#5-launch-docker-services) from the wiki is now built on the `chemcurator_default` network.  This will allow pgbouncer to talk to it using the container name "postgresql"
- There is a new section on the [Deploying with Docker](https://github.com/Chemical-Curation/chemcurator_django/wiki/Deploying-with-Docker) explaining how to find the resolver web container's url using a docker deployment.