### PR TITLE
306 compound err mgmt

### DIFF
--- a/chemreg/compound/serializers.py
+++ b/chemreg/compound/serializers.py
@@ -2,7 +2,6 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse as drf_reverse
 
-from indigo import IndigoException
 from rest_framework_json_api.utils import format_value
 
 from chemreg.common.serializers import CommonInfoSerializer, ControlledVocabSerializer
@@ -19,6 +18,7 @@ from chemreg.compound.validators import (
     validate_molfile_v3000_computable,
     validate_smiles,
 )
+from chemreg.indigo.errors import catch_compound_calc_error
 from chemreg.indigo.inchi import get_inchikey
 from chemreg.indigo.molfile import get_molfile_v3000
 from chemreg.jsonapi.serializers import PolymorphicModelSerializer
@@ -168,21 +168,19 @@ class DefinedCompoundDetailSerializer(DefinedCompoundSerializer):
             "calculated_inchikey",
         ]
 
+    @catch_compound_calc_error
     def get_molecular_weight(self, obj):
-        try:
-            return obj.indigo_structure.molecularWeight()
-        except IndigoException:
-            pass
+        return obj.indigo_structure.molecularWeight()
 
+    @catch_compound_calc_error
     def get_molecular_formula(self, obj):
-        try:
-            return obj.indigo_structure.grossFormula()
-        except IndigoException:
-            pass
+        return obj.indigo_structure.grossFormula()
 
+    @catch_compound_calc_error
     def get_smiles(self, obj):
         return obj.indigo_structure.smiles()
 
+    @catch_compound_calc_error
     def get_calculated_inchikey(self, obj):
         return get_inchikey(obj.molfile_v3000)
 

--- a/chemreg/compound/serializers.py
+++ b/chemreg/compound/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse as drf_reverse
 
+from indigo import IndigoException
 from rest_framework_json_api.utils import format_value
 
 from chemreg.common.serializers import CommonInfoSerializer, ControlledVocabSerializer
@@ -168,10 +169,16 @@ class DefinedCompoundDetailSerializer(DefinedCompoundSerializer):
         ]
 
     def get_molecular_weight(self, obj):
-        return obj.indigo_structure.molecularWeight()
+        try:
+            return obj.indigo_structure.molecularWeight()
+        except IndigoException:
+            pass
 
     def get_molecular_formula(self, obj):
-        return obj.indigo_structure.grossFormula()
+        try:
+            return obj.indigo_structure.grossFormula()
+        except IndigoException:
+            pass
 
     def get_smiles(self, obj):
         return obj.indigo_structure.smiles()

--- a/chemreg/compound/tests/test_views.py
+++ b/chemreg/compound/tests/test_views.py
@@ -6,7 +6,6 @@ from rest_framework.reverse import reverse
 from rest_framework.test import force_authenticate
 
 import pytest
-from indigo import IndigoException
 
 from chemreg.compound.tests.factories import (
     DefinedCompoundFactory,
@@ -259,6 +258,7 @@ def test_defined_compound_bad_valence(
 ):
     client.force_authenticate(user=admin_user)
     dc = defined_compound_factory.build(
+        # Molfile is for "FIBr"
         molfile_v3000="\n  -INDIGO-01192114142D\n\n  0  0  0  0  0  0  0  0  0  0  0 V3000\nM  V30 BEGIN CTAB\nM  V30 COUNTS 3 2 0 0 0\nM  V30 BEGIN ATOM\nM  V30 1 F 9.425 -3.15 0.0 0\nM  V30 2 I 10.425 -3.15 0.0 0\nM  V30 3 Br 11.425 -3.15 0.0 0\nM  V30 END ATOM\nM  V30 BEGIN BOND\nM  V30 1 1 1 2\nM  V30 2 1 2 3\nM  V30 END BOND\nM  V30 END CTAB\nM  END\n"
     )
 
@@ -269,12 +269,8 @@ def test_defined_compound_bad_valence(
     assert response.status_code == 201
     full_response_data = json.loads(response.content)["data"]
     url = reverse("basecompound-detail", [full_response_data.get("id")])
-    with pytest.raises(IndigoException) as err:
-        client.get(url).json()["data"]["attributes"]
-    assert (
-        str(err.value)
-        == "element: bad valence on I having 2 drawn bonds, charge 0, and 0 radical electrons"
-    )
+    # Assert no errors returned (assert fails if error returns)
+    assert client.get(url).json()["data"]["attributes"]
 
 
 @pytest.mark.django_db

--- a/chemreg/indigo/errors.py
+++ b/chemreg/indigo/errors.py
@@ -1,13 +1,21 @@
 import functools
+from typing import Any
 
 from indigo import IndigoException
 
 
-def catch_compound_calc_error(f):
+def catch_compound_calc_error(f: Any) -> Any:
     """
     A function wrapper for catching calculation errors.
     Primarially for catching 'indigo.IndigoException: element: bad valence...'
     errors and ensuring a 200 response.
+
+    Args:
+        f: a function to be wrapped.
+
+    Returns:
+        Either a calculated value (MW, MF, SMILES, Inchikey) or `null`
+
     """
 
     @functools.wraps(f)

--- a/chemreg/indigo/errors.py
+++ b/chemreg/indigo/errors.py
@@ -1,0 +1,20 @@
+import functools
+
+from indigo import IndigoException
+
+
+def catch_compound_calc_error(f):
+    """
+    A function wrapper for catching calculation errors.
+    Primarially for catching 'indigo.IndigoException: element: bad valence...'
+    errors and ensuring a 200 response.
+    """
+
+    @functools.wraps(f)
+    def i(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except IndigoException:
+            pass
+
+    return i


### PR DESCRIPTION
Closes #306 

Catches calculated Compound attribute errors.

- API response is `200`, 'failed' values are `null`
- Created decorator in `chemreg/indigo/errors.py` 
- Wrapped attribute calculation functions in `chemreg/compound/serializers.py`
- Added test, using "FIBr" molfile